### PR TITLE
Improve CLI and secrets type handling

### DIFF
--- a/buildarr_radarr/secrets.py
+++ b/buildarr_radarr/secrets.py
@@ -20,7 +20,7 @@ Plugin secrets file model.
 from __future__ import annotations
 
 from http import HTTPStatus
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import radarr
@@ -73,10 +73,12 @@ class RadarrSecrets(_RadarrSecrets):
             else (443 if protocol == "https" else 80)
         )
         return cls(
-            hostname=cast(NonEmptyStr, hostname),
-            port=cast(Port, port),
-            protocol=cast(RadarrProtocol, protocol),
-            api_key=cast(ArrApiKey, api_key),
+            **{  # type: ignore[arg-type]
+                "hostname": hostname,
+                "port": port,
+                "protocol": protocol,
+                "api_key": api_key,
+            },
         )
 
     @classmethod


### PR DESCRIPTION
* Parse the instance URL directly as a URL object when dumping configuration
* Eliminate the use of `cast` where possible in the CLI and secrets models