### PR TITLE
FIx misleading root folder state logging

### DIFF
--- a/buildarr_radarr/config/settings/media_management.py
+++ b/buildarr_radarr/config/settings/media_management.py
@@ -160,7 +160,7 @@ class RootFoldersSettings(RadarrConfigBase):
                         rootfolder_api.delete_root_folder(id=rootfolder_id)
                         changed = True
                     else:
-                        logger.info("%s[%i]: %s -> (unmanaged)", tree, i, repr(str(root_folder)))
+                        logger.debug("%s[%i]: %s (unmanaged)", tree, i, repr(str(root_folder)))
                     i -= 1
         return changed
 


### PR DESCRIPTION
* Change the log level of the unmanaged root folder state log from `INFO` to `DEBUG`
* Remove the misleading arrow from the unmanaged root folder state log to avoid implying that the state changed