### PR TITLE
Fix Newznab/Torznab indexer bugs

### DIFF
--- a/buildarr_radarr/config/settings/indexers/torrent/torznab.py
+++ b/buildarr_radarr/config/settings/indexers/torrent/torznab.py
@@ -19,7 +19,7 @@ Torznab indexer configuration.
 
 from __future__ import annotations
 
-from typing import List, Literal, Optional, Set, Union
+from typing import Iterable, List, Literal, Optional, Set, Union
 
 from buildarr.config import RemoteMapEntry
 from buildarr.types import NonEmptyStr, Password
@@ -108,8 +108,12 @@ class TorznabIndexer(TorrentIndexer):
         ),
     ]
 
-    @validator("categories", each_item=True)
-    def validate_category(cls, value: Union[NabCategory, int]) -> Union[NabCategory, int]:
-        if isinstance(value, int):
-            return NabCategory.decode(value)
-        return value
+    @validator("categories")
+    def validate_categories(
+        cls,
+        value: Iterable[Union[NabCategory, int]],
+    ) -> Set[Union[NabCategory, int]]:
+        return set(
+            NabCategory.decode(category) if isinstance(category, int) else category
+            for category in value
+        )

--- a/buildarr_radarr/config/settings/indexers/torrent/torznab.py
+++ b/buildarr_radarr/config/settings/indexers/torrent/torznab.py
@@ -108,7 +108,7 @@ class TorznabIndexer(TorrentIndexer):
         ),
     ]
 
-    @validator(each_item=True)
+    @validator("categories", each_item=True)
     def validate_category(cls, value: Union[NabCategory, int]) -> Union[NabCategory, int]:
         if isinstance(value, int):
             return NabCategory.decode(value)

--- a/buildarr_radarr/config/settings/indexers/torrent/torznab.py
+++ b/buildarr_radarr/config/settings/indexers/torrent/torznab.py
@@ -101,7 +101,9 @@ class TorznabIndexer(TorrentIndexer):
             {
                 "is_field": True,
                 "decoder": lambda v: set(NabCategory.decode(c) for c in v),
-                "encoder": lambda v: sorted(c.value for c in v),
+                "encoder": lambda v: sorted(
+                    ((c.value if isinstance(c, NabCategory) else c) for c in v),
+                ),
             },
         ),
         ("remove_year", "removeYear", {"is_field": True}),

--- a/buildarr_radarr/config/settings/indexers/torrent/torznab.py
+++ b/buildarr_radarr/config/settings/indexers/torrent/torznab.py
@@ -19,7 +19,9 @@ Torznab indexer configuration.
 
 from __future__ import annotations
 
-from typing import List, Literal, Optional, Set, Union
+from typing import List, Literal, Mapping, Optional, Set, Union
+
+import radarr
 
 from buildarr.config import RemoteMapEntry
 from buildarr.types import NonEmptyStr, Password
@@ -91,25 +93,37 @@ class TorznabIndexer(TorrentIndexer):
     """
 
     _implementation = "Torznab"
-    _remote_map: List[RemoteMapEntry] = [
-        ("base_url", "baseUrl", {"is_field": True}),
-        ("api_path", "apiPath", {"is_field": True}),
-        ("api_key", "apiKey", {"is_field": True}),
-        (
-            "categories",
-            "categories",
-            {"is_field": True},  # , "decoder": },
-        ),
-        (
-            "additional_parameters",
-            "additionalParameters",
-            {"is_field": True, "field_default": None, "decoder": lambda v: v or None},
-        ),
-    ]
+
+    @classmethod
+    def _get_remote_map(
+        cls,
+        api_schema: radarr.IndexerResource,
+        downloadclient_ids: Mapping[str, int],
+        tag_ids: Mapping[str, int],
+    ) -> List[RemoteMapEntry]:
+        return [
+            ("base_url", "baseUrl", {"is_field": True}),
+            ("api_path", "apiPath", {"is_field": True}),
+            ("api_key", "apiKey", {"is_field": True}),
+            (
+                "categories",
+                "categories",
+                {"is_field": True},
+                # {"is_field": True, "decoder": lambda v: set(cls._category_decoder(c) for c in v)},
+            ),
+            (
+                "additional_parameters",
+                "additionalParameters",
+                {"is_field": True},
+                # {"is_field": True, "field_default": None, "decoder": lambda v: v or None},
+            ),
+        ]
 
     @classmethod
     def _category_decoder(cls, value: int) -> Union[NabCategory, int]:
         try:
+            print("converting to NabCategory")  # noqa: T201
             return NabCategory(value)
         except ValueError:
+            print("converting to NabCategory failed, returning value direct")  # noqa: T201
             return value

--- a/buildarr_radarr/config/settings/indexers/torrent/torznab.py
+++ b/buildarr_radarr/config/settings/indexers/torrent/torznab.py
@@ -23,7 +23,7 @@ from typing import List, Literal, Optional, Set, Union
 
 from buildarr.config import RemoteMapEntry
 from buildarr.types import NonEmptyStr, Password
-from pydantic import AnyHttpUrl
+from pydantic import AnyHttpUrl, validator
 
 from ..util import NabCategory
 from .base import TorrentIndexer
@@ -98,11 +98,7 @@ class TorznabIndexer(TorrentIndexer):
         (
             "categories",
             "categories",
-            {
-                "is_field": True,
-                "decoder": lambda v: set(NabCategory.decode(c) for c in v),
-                "encoder": lambda v: sorted(NabCategory.encode(c) for c in v),
-            },
+            {"is_field": True, "encoder": lambda v: sorted(NabCategory.encode(c) for c in v)},
         ),
         ("remove_year", "removeYear", {"is_field": True}),
         (
@@ -111,3 +107,9 @@ class TorznabIndexer(TorrentIndexer):
             {"is_field": True, "field_default": None, "decoder": lambda v: v or None},
         ),
     ]
+
+    @validator(each_item=True)
+    def validate_category(cls, value: Union[NabCategory, int]) -> Union[NabCategory, int]:
+        if isinstance(value, int):
+            return NabCategory.decode(value)
+        return value

--- a/buildarr_radarr/config/settings/indexers/torrent/torznab.py
+++ b/buildarr_radarr/config/settings/indexers/torrent/torznab.py
@@ -101,9 +101,7 @@ class TorznabIndexer(TorrentIndexer):
             {
                 "is_field": True,
                 "decoder": lambda v: set(NabCategory.decode(c) for c in v),
-                "encoder": lambda v: sorted(
-                    ((c.value if isinstance(c, NabCategory) else c) for c in v),
-                ),
+                "encoder": lambda v: sorted(NabCategory.encode(c) for c in v),
             },
         ),
         ("remove_year", "removeYear", {"is_field": True}),

--- a/buildarr_radarr/config/settings/indexers/torrent/torznab.py
+++ b/buildarr_radarr/config/settings/indexers/torrent/torznab.py
@@ -19,9 +19,7 @@ Torznab indexer configuration.
 
 from __future__ import annotations
 
-from typing import List, Literal, Mapping, Optional, Set, Union
-
-import radarr
+from typing import List, Literal, Optional, Set, Union
 
 from buildarr.config import RemoteMapEntry
 from buildarr.types import NonEmptyStr, Password
@@ -55,13 +53,13 @@ class TorznabIndexer(TorrentIndexer):
     """
 
     categories: Set[Union[NabCategory, int]] = {
-        NabCategory.MOVIES_FOREIGN,  # type: ignore[arg-type]
-        NabCategory.MOVIES_OTHER,  # type: ignore[arg-type]
-        NabCategory.MOVIES_SD,  # type: ignore[arg-type]
-        NabCategory.MOVIES_HD,  # type: ignore[arg-type]
-        NabCategory.MOVIES_UHD,  # type: ignore[arg-type]
-        NabCategory.MOVIES_BLURAY,  # type: ignore[arg-type]
-        NabCategory.MOVIES_3D,  # type: ignore[arg-type]
+        NabCategory.MOVIES_FOREIGN,
+        NabCategory.MOVIES_OTHER,
+        NabCategory.MOVIES_SD,
+        NabCategory.MOVIES_HD,
+        NabCategory.MOVIES_UHD,
+        NabCategory.MOVIES_BLURAY,
+        NabCategory.MOVIES_3D,
     }
     """
     Categories to monitor for standard/daily shows.
@@ -93,37 +91,23 @@ class TorznabIndexer(TorrentIndexer):
     """
 
     _implementation = "Torznab"
-
-    @classmethod
-    def _get_remote_map(
-        cls,
-        api_schema: radarr.IndexerResource,
-        downloadclient_ids: Mapping[str, int],
-        tag_ids: Mapping[str, int],
-    ) -> List[RemoteMapEntry]:
-        return [
-            ("base_url", "baseUrl", {"is_field": True}),
-            ("api_path", "apiPath", {"is_field": True}),
-            ("api_key", "apiKey", {"is_field": True}),
-            (
-                "categories",
-                "categories",
-                {"is_field": True},
-                # {"is_field": True, "decoder": lambda v: set(cls._category_decoder(c) for c in v)},
-            ),
-            (
-                "additional_parameters",
-                "additionalParameters",
-                {"is_field": True},
-                # {"is_field": True, "field_default": None, "decoder": lambda v: v or None},
-            ),
-        ]
-
-    @classmethod
-    def _category_decoder(cls, value: int) -> Union[NabCategory, int]:
-        try:
-            print("converting to NabCategory")  # noqa: T201
-            return NabCategory(value)
-        except ValueError:
-            print("converting to NabCategory failed, returning value direct")  # noqa: T201
-            return value
+    _remote_map: List[RemoteMapEntry] = [
+        ("base_url", "baseUrl", {"is_field": True}),
+        ("api_path", "apiPath", {"is_field": True}),
+        ("api_key", "apiKey", {"is_field": True}),
+        (
+            "categories",
+            "categories",
+            {
+                "is_field": True,
+                "decoder": lambda v: set(NabCategory.decode(c) for c in v),
+                "encoder": lambda v: sorted(c.value for c in v),
+            },
+        ),
+        ("remove_year", "removeYear", {"is_field": True}),
+        (
+            "additional_parameters",
+            "additionalParameters",
+            {"is_field": True, "field_default": None, "decoder": lambda v: v or None},
+        ),
+    ]

--- a/buildarr_radarr/config/settings/indexers/torrent/torznab.py
+++ b/buildarr_radarr/config/settings/indexers/torrent/torznab.py
@@ -19,7 +19,7 @@ Torznab indexer configuration.
 
 from __future__ import annotations
 
-from typing import List, Literal, Optional, Set
+from typing import List, Literal, Optional, Set, Union
 
 from buildarr.config import RemoteMapEntry
 from buildarr.types import NonEmptyStr, Password
@@ -52,14 +52,14 @@ class TorznabIndexer(TorrentIndexer):
     API key for use with the Torznab API.
     """
 
-    categories: Set[NabCategory] = {
-        NabCategory.MOVIES_FOREIGN,
-        NabCategory.MOVIES_OTHER,
-        NabCategory.MOVIES_SD,
-        NabCategory.MOVIES_HD,
-        NabCategory.MOVIES_UHD,
-        NabCategory.MOVIES_BLURAY,
-        NabCategory.MOVIES_3D,
+    categories: Set[Union[NabCategory, int]] = {
+        NabCategory.MOVIES_FOREIGN,  # type: ignore[arg-type]
+        NabCategory.MOVIES_OTHER,  # type: ignore[arg-type]
+        NabCategory.MOVIES_SD,  # type: ignore[arg-type]
+        NabCategory.MOVIES_HD,  # type: ignore[arg-type]
+        NabCategory.MOVIES_UHD,  # type: ignore[arg-type]
+        NabCategory.MOVIES_BLURAY,  # type: ignore[arg-type]
+        NabCategory.MOVIES_3D,  # type: ignore[arg-type]
     }
     """
     Categories to monitor for standard/daily shows.
@@ -68,13 +68,16 @@ class TorznabIndexer(TorrentIndexer):
     Values:
 
     * `Movies`
-    * `Movies-Foreign`
-    * `Movies-Other`
-    * `Movies-SD`
-    * `Movies-HD`
-    * `Movies-UHD`
-    * `Movies-Bluray`
-    * `Movies-3D`
+    * `Movies/Foreign`
+    * `Movies/Other`
+    * `Movies/SD`
+    * `Movies/HD`
+    * `Movies/UHD`
+    * `Movies/BluRay`
+    * `Movies/3D`
+    * `Movies/DVD`
+    * `Movies/WEB-DL`
+    * `Movies/x265`
     """
 
     remove_year: bool = False
@@ -92,10 +95,21 @@ class TorznabIndexer(TorrentIndexer):
         ("base_url", "baseUrl", {"is_field": True}),
         ("api_path", "apiPath", {"is_field": True}),
         ("api_key", "apiKey", {"is_field": True}),
-        ("categories", "categories", {"is_field": True}),
+        (
+            "categories",
+            "categories",
+            {"is_field": True},  # , "decoder": },
+        ),
         (
             "additional_parameters",
             "additionalParameters",
             {"is_field": True, "field_default": None, "decoder": lambda v: v or None},
         ),
     ]
+
+    @classmethod
+    def _category_decoder(cls, value: int) -> Union[NabCategory, int]:
+        try:
+            return NabCategory(value)
+        except ValueError:
+            return value

--- a/buildarr_radarr/config/settings/indexers/usenet/newznab.py
+++ b/buildarr_radarr/config/settings/indexers/usenet/newznab.py
@@ -53,13 +53,13 @@ class NewznabIndexer(UsenetIndexer):
     """
 
     categories: Set[NabCategory] = {
-        NabCategory.MOVIES_FOREIGN,
-        NabCategory.MOVIES_OTHER,
-        NabCategory.MOVIES_SD,
-        NabCategory.MOVIES_HD,
-        NabCategory.MOVIES_UHD,
-        NabCategory.MOVIES_BLURAY,
-        NabCategory.MOVIES_3D,
+        NabCategory.MOVIES_FOREIGN,  # type: ignore[arg-type]
+        NabCategory.MOVIES_OTHER,  # type: ignore[arg-type]
+        NabCategory.MOVIES_SD,  # type: ignore[arg-type]
+        NabCategory.MOVIES_HD,  # type: ignore[arg-type]
+        NabCategory.MOVIES_UHD,  # type: ignore[arg-type]
+        NabCategory.MOVIES_BLURAY,  # type: ignore[arg-type]
+        NabCategory.MOVIES_3D,  # type: ignore[arg-type]
     }
     """
     Categories to monitor for release.
@@ -68,13 +68,16 @@ class NewznabIndexer(UsenetIndexer):
     Values:
 
     * `Movies`
-    * `Movies-Foreign`
-    * `Movies-Other`
-    * `Movies-SD`
-    * `Movies-HD`
-    * `Movies-UHD`
-    * `Movies-Bluray`
-    * `Movies-3D`
+    * `Movies/Foreign`
+    * `Movies/Other`
+    * `Movies/SD`
+    * `Movies/HD`
+    * `Movies/UHD`
+    * `Movies/BluRay`
+    * `Movies/3D`
+    * `Movies/DVD`
+    * `Movies/WEB-DL`
+    * `Movies/x265`
     """
 
     remove_year: bool = False

--- a/buildarr_radarr/config/settings/indexers/usenet/newznab.py
+++ b/buildarr_radarr/config/settings/indexers/usenet/newznab.py
@@ -53,13 +53,13 @@ class NewznabIndexer(UsenetIndexer):
     """
 
     categories: Set[NabCategory] = {
-        NabCategory.MOVIES_FOREIGN,  # type: ignore[arg-type]
-        NabCategory.MOVIES_OTHER,  # type: ignore[arg-type]
-        NabCategory.MOVIES_SD,  # type: ignore[arg-type]
-        NabCategory.MOVIES_HD,  # type: ignore[arg-type]
-        NabCategory.MOVIES_UHD,  # type: ignore[arg-type]
-        NabCategory.MOVIES_BLURAY,  # type: ignore[arg-type]
-        NabCategory.MOVIES_3D,  # type: ignore[arg-type]
+        NabCategory.MOVIES_FOREIGN,
+        NabCategory.MOVIES_OTHER,
+        NabCategory.MOVIES_SD,
+        NabCategory.MOVIES_HD,
+        NabCategory.MOVIES_UHD,
+        NabCategory.MOVIES_BLURAY,
+        NabCategory.MOVIES_3D,
     }
     """
     Categories to monitor for release.
@@ -100,8 +100,13 @@ class NewznabIndexer(UsenetIndexer):
         (
             "categories",
             "categories",
-            {"is_field": True, "encoder": lambda v: sorted(c.value for c in v)},
+            {
+                "is_field": True,
+                "decoder": lambda v: set(NabCategory.decode(c) for c in v),
+                "encoder": lambda v: sorted(c.value for c in v),
+            },
         ),
+        ("remove_year", "removeYear", {"is_field": True}),
         (
             "additional_parameters",
             "additionalParameters",

--- a/buildarr_radarr/config/settings/indexers/usenet/newznab.py
+++ b/buildarr_radarr/config/settings/indexers/usenet/newznab.py
@@ -19,7 +19,7 @@ Newznab indexer configuration.
 
 from __future__ import annotations
 
-from typing import List, Literal, Optional, Set, Union
+from typing import Iterable, List, Literal, Optional, Set, Union
 
 from buildarr.config import RemoteMapEntry
 from buildarr.types import NonEmptyStr, Password
@@ -110,8 +110,12 @@ class NewznabIndexer(UsenetIndexer):
         ),
     ]
 
-    @validator("categories", each_item=True)
-    def validate_category(cls, value: Union[NabCategory, int]) -> Union[NabCategory, int]:
-        if isinstance(value, int):
-            return NabCategory.decode(value)
-        return value
+    @validator("categories")
+    def validate_categories(
+        cls,
+        value: Iterable[Union[NabCategory, int]],
+    ) -> Set[Union[NabCategory, int]]:
+        return set(
+            NabCategory.decode(category) if isinstance(category, int) else category
+            for category in value
+        )

--- a/buildarr_radarr/config/settings/indexers/usenet/newznab.py
+++ b/buildarr_radarr/config/settings/indexers/usenet/newznab.py
@@ -110,7 +110,7 @@ class NewznabIndexer(UsenetIndexer):
         ),
     ]
 
-    @validator(each_item=True)
+    @validator("categories", each_item=True)
     def validate_category(cls, value: Union[NabCategory, int]) -> Union[NabCategory, int]:
         if isinstance(value, int):
             return NabCategory.decode(value)

--- a/buildarr_radarr/config/settings/indexers/usenet/newznab.py
+++ b/buildarr_radarr/config/settings/indexers/usenet/newznab.py
@@ -103,9 +103,7 @@ class NewznabIndexer(UsenetIndexer):
             {
                 "is_field": True,
                 "decoder": lambda v: set(NabCategory.decode(c) for c in v),
-                "encoder": lambda v: sorted(
-                    ((c.value if isinstance(c, NabCategory) else c) for c in v),
-                ),
+                "encoder": lambda v: sorted(NabCategory.encode(c) for c in v),
             },
         ),
         ("remove_year", "removeYear", {"is_field": True}),

--- a/buildarr_radarr/config/settings/indexers/usenet/newznab.py
+++ b/buildarr_radarr/config/settings/indexers/usenet/newznab.py
@@ -103,7 +103,9 @@ class NewznabIndexer(UsenetIndexer):
             {
                 "is_field": True,
                 "decoder": lambda v: set(NabCategory.decode(c) for c in v),
-                "encoder": lambda v: sorted(c.value for c in v),
+                "encoder": lambda v: sorted(
+                    ((c.value if isinstance(c, NabCategory) else c) for c in v),
+                ),
             },
         ),
         ("remove_year", "removeYear", {"is_field": True}),

--- a/buildarr_radarr/config/settings/indexers/util.py
+++ b/buildarr_radarr/config/settings/indexers/util.py
@@ -20,28 +20,92 @@ Indexer configuration utility classes and functions.
 from __future__ import annotations
 
 from logging import getLogger
+from typing import TYPE_CHECKING
 
-from buildarr.types import BaseEnum
+from aenum import MultiValueEnum
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, Generator
+
+    from typing_extensions import Self
 
 logger = getLogger(__name__)
 
 
-class NabCategory(BaseEnum):
-    MOVIES = 2000
-    MOVIES_FOREIGN = 2010
-    MOVIES_OTHER = 2020
-    MOVIES_SD = 2030
-    MOVIES_HD = 2040
-    MOVIES_UHD = 2045
-    MOVIES_BLURAY = 2050
-    MOVIES_3D = 2060
-    MOVIES_DVD = 2070
+class NabCategory(MultiValueEnum):
+    # https://github.com/Prowlarr/Prowlarr/blob/develop/src/NzbDrone.Core/Indexers/NewznabStandardCategory.cs
+    MOVIES = (2000, "Movies")
+    MOVIES_FOREIGN = (2010, "Movies/Foreign")
+    MOVIES_OTHER = (2020, "Movies/Other")
+    MOVIES_SD = (2030, "Movies/SD")
+    MOVIES_HD = (2040, "Movies/HD")
+    MOVIES_UHD = (2045, "Movies/UHD")
+    MOVIES_BLURAY = (2050, "Movies/BluRay")
+    MOVIES_3D = (2060, "Movies/3D")
+    MOVIES_DVD = (2070, "Movies/DVD")
+    MOVIES_WEBDL = (2080, "Movies/WEB-DL")
+    MOVIES_X265 = (2090, "Movies/x265")
 
-    # TODO: Make the enum also accept these values.
-    # MOVIES_FOREIGN = "Movies/Foreign"
-    # MOVIES_OTHER = "Movies/Other"
-    # MOVIES_SD = "Movies/SD"
-    # MOVIES_HD = "Movies/HD"
-    # MOVIES_UHD = "Movies/UHD"
-    # MOVIES_3D = "Movies/3D"
-    # MOVIES_DVD = "Movies/DVD"
+    @classmethod
+    def from_name_str(cls, name_str: str) -> Self:
+        """
+        Get the enumeration object corresponding to the given name case-insensitively.
+
+        Args:
+            name_str (str): Name of the enumeration value, or its remote representation.
+
+        Raises:
+            KeyError: When the enumeration name is invalid (does not exist).
+
+        Returns:
+            The enumeration object for the given name
+        """
+        name = name_str.lower().replace("/", "_").replace("-", "_")
+        for obj in cls:  # type: ignore[attr-defined]
+            if (
+                obj.name.lower() == name
+                or obj.values[1].lower().replace("/", "_").replace("-", "_") == name
+            ):
+                return obj
+        raise KeyError(repr(name))
+
+    def to_name_str(self) -> str:
+        """
+        Return the name for this enumaration object.
+
+        Returns:
+            Remote representation name
+        """
+        return self.values[1]
+
+    @classmethod
+    def __get_validators__(cls) -> Generator[Callable[[Any], Self], None, None]:
+        """
+        Pass class validation functions to Pydantic.
+
+        Yields:
+            Validation class functions
+        """
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value: Any) -> Self:
+        """
+        Validate and coerce the given value to an enumeration object.
+
+        Args:
+            value (Any): Object to validate and coerce
+
+        Raises:
+            ValueError: If a enumeration object corresponding with the value cannot be found
+
+        Returns:
+            Enumeration object corresponding to the given value
+        """
+        try:
+            return cls(value)
+        except ValueError:
+            try:
+                return cls.from_name_str(value)
+            except (TypeError, KeyError):
+                raise ValueError(f"Invalid {cls.__name__} name or value: {value}") from None

--- a/buildarr_radarr/config/settings/indexers/util.py
+++ b/buildarr_radarr/config/settings/indexers/util.py
@@ -20,7 +20,7 @@ Indexer configuration utility classes and functions.
 from __future__ import annotations
 
 from logging import getLogger
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from buildarr.types import BaseEnum
 
@@ -52,3 +52,7 @@ class NabCategory(BaseEnum):
             return cls(value)
         except ValueError:
             return value
+
+    @classmethod
+    def encode(cls, value: Union[Self, int]) -> int:
+        return value if isinstance(value, int) else cast(int, value.value)

--- a/buildarr_radarr/config/settings/indexers/util.py
+++ b/buildarr_radarr/config/settings/indexers/util.py
@@ -22,17 +22,17 @@ from __future__ import annotations
 from logging import getLogger
 from typing import TYPE_CHECKING
 
-from aenum import MultiValueEnum
+from buildarr.types import BaseEnum
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Generator
+    from typing import Union
 
     from typing_extensions import Self
 
 logger = getLogger(__name__)
 
 
-class NabCategory(MultiValueEnum):
+class NabCategory(BaseEnum):
     # https://github.com/Prowlarr/Prowlarr/blob/develop/src/NzbDrone.Core/Indexers/NewznabStandardCategory.cs
     MOVIES = (2000, "Movies")
     MOVIES_FOREIGN = (2010, "Movies/Foreign")
@@ -47,65 +47,8 @@ class NabCategory(MultiValueEnum):
     MOVIES_X265 = (2090, "Movies/x265")
 
     @classmethod
-    def from_name_str(cls, name_str: str) -> Self:
-        """
-        Get the enumeration object corresponding to the given name case-insensitively.
-
-        Args:
-            name_str (str): Name of the enumeration value, or its remote representation.
-
-        Raises:
-            KeyError: When the enumeration name is invalid (does not exist).
-
-        Returns:
-            The enumeration object for the given name
-        """
-        name = name_str.lower().replace("/", "_").replace("-", "_")
-        for obj in cls:  # type: ignore[attr-defined]
-            if (
-                obj.name.lower() == name
-                or obj.values[1].lower().replace("/", "_").replace("-", "_") == name
-            ):
-                return obj
-        raise KeyError(repr(name))
-
-    def to_name_str(self) -> str:
-        """
-        Return the name for this enumaration object.
-
-        Returns:
-            Remote representation name
-        """
-        return self.values[1]
-
-    @classmethod
-    def __get_validators__(cls) -> Generator[Callable[[Any], Self], None, None]:
-        """
-        Pass class validation functions to Pydantic.
-
-        Yields:
-            Validation class functions
-        """
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, value: Any) -> Self:
-        """
-        Validate and coerce the given value to an enumeration object.
-
-        Args:
-            value (Any): Object to validate and coerce
-
-        Raises:
-            ValueError: If a enumeration object corresponding with the value cannot be found
-
-        Returns:
-            Enumeration object corresponding to the given value
-        """
+    def decode(cls, value: int) -> Union[Self, int]:
         try:
             return cls(value)
         except ValueError:
-            try:
-                return cls.from_name_str(value)
-            except (TypeError, KeyError):
-                raise ValueError(f"Invalid {cls.__name__} name or value: {value}") from None
+            return value

--- a/buildarr_radarr/config/settings/quality.py
+++ b/buildarr_radarr/config/settings/quality.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, Mapping, Optional, cast
 
 import radarr
 
-from buildarr.config import ConfigBase, ConfigTrashIDNotFoundError
+from buildarr.config import ConfigTrashIDNotFoundError
 from buildarr.state import state
 from buildarr.types import TrashID
 from pydantic import Field, validator
@@ -145,7 +145,7 @@ class QualityDefinition(RadarrConfigBase):
         return value
 
 
-class RadarrQualitySettings(ConfigBase):
+class RadarrQualitySettings(RadarrConfigBase):
     # Quality definition settings configuration.
     #
     # For more information on how to configure this, refer to the plugin docs.

--- a/buildarr_radarr/config/types.py
+++ b/buildarr_radarr/config/types.py
@@ -21,15 +21,24 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from aenum import MultiValueEnum
 from buildarr.config import ConfigBase
 
 if TYPE_CHECKING:
     from ..secrets import RadarrSecrets
 
-    class RadarrConfigBase(ConfigBase[RadarrSecrets]):
+    class _RadarrConfigBase(ConfigBase[RadarrSecrets]):
         ...
 
 else:
 
-    class RadarrConfigBase(ConfigBase):
+    class _RadarrConfigBase(ConfigBase):
         ...
+
+
+class RadarrConfigBase(_RadarrConfigBase):
+    class Config(_RadarrConfigBase.Config):
+        json_encoders = {
+            **_RadarrConfigBase.Config.json_encoders,
+            MultiValueEnum: lambda v: v.to_name_str(),
+        }

--- a/buildarr_radarr/config/types.py
+++ b/buildarr_radarr/config/types.py
@@ -26,14 +26,10 @@ from buildarr.config import ConfigBase
 if TYPE_CHECKING:
     from ..secrets import RadarrSecrets
 
-    class _RadarrConfigBase(ConfigBase[RadarrSecrets]):
+    class RadarrConfigBase(ConfigBase[RadarrSecrets]):
         ...
 
 else:
 
-    class _RadarrConfigBase(ConfigBase):
+    class RadarrConfigBase(ConfigBase):
         ...
-
-
-class RadarrConfigBase(_RadarrConfigBase):
-    pass

--- a/buildarr_radarr/config/types.py
+++ b/buildarr_radarr/config/types.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from aenum import MultiValueEnum
 from buildarr.config import ConfigBase
 
 if TYPE_CHECKING:
@@ -37,8 +36,4 @@ else:
 
 
 class RadarrConfigBase(_RadarrConfigBase):
-    class Config(_RadarrConfigBase.Config):
-        json_encoders = {
-            **_RadarrConfigBase.Config.json_encoders,
-            MultiValueEnum: lambda v: v.to_name_str(),
-        }
+    pass

--- a/poetry.lock
+++ b/poetry.lock
@@ -1027,4 +1027,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "b6235009d9d0ce10f6f53a153007f07aecfb080fac16e71be45e06eeed2d31c1"
+content-hash = "ca03936376a9888c21f2ddef03916f36af41f1fa2423d3d95f4e2eea1191927c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -291,13 +291,13 @@ dev = ["flake8", "markdown", "twine", "wheel"]
 
 [[package]]
 name = "griffe"
-version = "0.36.9"
+version = "0.37.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "griffe-0.36.9-py3-none-any.whl", hash = "sha256:7874febe7cd81e8e47eb7b8130ff9d38c8f3656233c01d2d217d2e898a0925f5"},
-    {file = "griffe-0.36.9.tar.gz", hash = "sha256:b4e510bf0ed1fc91c58453c68018a2247c561adec8f5dadc40275afc01f51eac"},
+    {file = "griffe-0.37.0-py3-none-any.whl", hash = "sha256:46a405e620f6de6f0692756862c2fd94cff2f1a9a075079c9b6b02c2a4c8abb5"},
+    {file = "griffe-0.37.0.tar.gz", hash = "sha256:a4e6741e6c8dbd3436b234cfd93e42fc039c1e1a622fee9f455ec2cdfb117c25"},
 ]
 
 [package.dependencies]
@@ -523,17 +523,17 @@ python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
 
 [[package]]
 name = "mkdocstrings-python"
-version = "1.7.3"
+version = "1.7.4"
 description = "A Python handler for mkdocstrings."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocstrings_python-1.7.3-py3-none-any.whl", hash = "sha256:2439d6ad3e34f0bb4c643b845fb3c06ae9233499a1736f9fa273424b75cc5894"},
-    {file = "mkdocstrings_python-1.7.3.tar.gz", hash = "sha256:c20128fa96c24dbc6437b10dfedaf33b0415d4503e51ce9ce5e84b271278268e"},
+    {file = "mkdocstrings_python-1.7.4-py3-none-any.whl", hash = "sha256:70eacbe5f2d5071f2e525ba0b35bc447d398437dfbcd90c63fe6e977551cfe26"},
+    {file = "mkdocstrings_python-1.7.4.tar.gz", hash = "sha256:c2fc34efd70000ec31aee247910006e8dd9d1b9f3957bf46880c3f6e51a8f0d5"},
 ]
 
 [package.dependencies]
-griffe = ">=0.35"
+griffe = ">=0.37"
 mkdocstrings = ">=0.20"
 
 [[package]]
@@ -1027,4 +1027,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "ca03936376a9888c21f2ddef03916f36af41f1fa2423d3d95f4e2eea1191927c"
+content-hash = "b6235009d9d0ce10f6f53a153007f07aecfb080fac16e71be45e06eeed2d31c1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -56,16 +56,17 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "buildarr"
-version = "0.7.0"
+version = "0.7.1"
 description = "Constructs and configures Arr PVR stacks"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "buildarr-0.7.0-py3-none-any.whl", hash = "sha256:a66fe550a338584c9bca0ef06eb754a8e25369800ed3443619c0cff9489eade5"},
-    {file = "buildarr-0.7.0.tar.gz", hash = "sha256:23b35ef507b2aa71aae4ceabdf3cfbf2fb454b07378a4c423a9387f6ded776ed"},
+    {file = "buildarr-0.7.1-py3-none-any.whl", hash = "sha256:a7118eaa57dc093a2b61baf98a77a47a86f2c35dc33000ab6cbefc090aade19c"},
+    {file = "buildarr-0.7.1.tar.gz", hash = "sha256:1666050a17a1c0d60aec3fb006e8ee101974d92c5d283ed4042ee319179eaa73"},
 ]
 
 [package.dependencies]
+aenum = "*"
 click = ">=8.0.4"
 click-params = ">=0.4.1"
 importlib-metadata = ">=4.6.0"
@@ -1027,4 +1028,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "ca03936376a9888c21f2ddef03916f36af41f1fa2423d3d95f4e2eea1191927c"
+content-hash = "9f4ef6a94a297ef77e1ab3286be82e8e9804ea63bd91be660ac94498ddb5c1b6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ packages = [{include = "buildarr_radarr"}]
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
 radarr-py = ">=0.4.0,<0.5.0"
-buildarr = ">=0.7.0,<0.8.0"
+buildarr = ">=0.7.1,<0.8.0"
 packaging = "*"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ packages = [{include = "buildarr_radarr"}]
 python = ">=3.8,<4.0"
 radarr-py = ">=0.4.0,<0.5.0"
 buildarr = ">=0.7.0,<0.8.0"
-aenum = "*"
 packaging = "*"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,5 @@ pretty = true
 [[tool.mypy.overrides]]
 module = [
     "radarr.*",
-    "aenum.*",
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ packages = [{include = "buildarr_radarr"}]
 python = ">=3.8,<4.0"
 radarr-py = ">=0.4.0,<0.5.0"
 buildarr = ">=0.7.0,<0.8.0"
+aenum = "*"
 packaging = "*"
 
 [tool.poetry.group.dev.dependencies]
@@ -106,5 +107,6 @@ pretty = true
 [[tool.mypy.overrides]]
 module = [
     "radarr.*",
+    "aenum.*",
 ]
 ignore_missing_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ aenum==3.1.15 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:27b1710b9d084de6e2e695dab78fe9f269de924b51ae2850170ee7e1ca6288a5 \
     --hash=sha256:8cbd76cd18c4f870ff39b24284d3ea028fbe8731a58df3aa581e434c575b9559 \
     --hash=sha256:e0dfaeea4c2bd362144b87377e2c61d91958c5ed0b4daf89cb6f45ae23af6288
-buildarr==0.7.0 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:23b35ef507b2aa71aae4ceabdf3cfbf2fb454b07378a4c423a9387f6ded776ed \
-    --hash=sha256:a66fe550a338584c9bca0ef06eb754a8e25369800ed3443619c0cff9489eade5
+buildarr==0.7.1 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:1666050a17a1c0d60aec3fb006e8ee101974d92c5d283ed4042ee319179eaa73 \
+    --hash=sha256:a7118eaa57dc093a2b61baf98a77a47a86f2c35dc33000ab6cbefc090aade19c
 certifi==2023.7.22 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082 \
     --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9


### PR DESCRIPTION
* Set the minimum Buildarr Core version to v0.7.1 for multi-value enumeration support
* Change `NabCategory` to a multi-value enumeration so the proper Newznab/Torznab category names can be used
* Accept raw integer values in the Buildarr configuration so that new values added in Radarr and Prowlarr do not cause errors to be raised in Buildarr
* Fix managing the `remove_year` parameter on Newznab/Torznab indexers
* Fix configuration model that was subclassing `ConfigBase` instead of `RadarrConfigBase`