### PR TITLE
Fix and improve configuration dumping

### DIFF
--- a/buildarr_radarr/cli.py
+++ b/buildarr_radarr/cli.py
@@ -58,7 +58,10 @@ def radarr():
     "--api-key",
     "api_key",
     metavar="API-KEY",
-    default=functools.partial(getpass, "Radarr instance API key: "),
+    default=functools.partial(
+        getpass,
+        "Radarr instance API key (or leave blank to auto-fetch): ",
+    ),
     help="API key of the Radarr instance. The user will be prompted if undefined.",
 )
 def dump_config(url: Url, api_key: str) -> int:
@@ -76,23 +79,23 @@ def dump_config(url: Url, api_key: str) -> int:
         else (443 if protocol == "https" else 80)
     )
 
+    instance_config = RadarrInstanceConfig(
+        **{  # type: ignore[arg-type]
+            "hostname": hostname,
+            "port": port,
+            "protocol": protocol,
+        },
+    )
+
     click.echo(
         RadarrManager()
         .from_remote(
-            instance_config=RadarrInstanceConfig(
-                **{  # type: ignore[arg-type]
-                    "hostname": hostname,
-                    "port": port,
-                    "protocol": protocol,
-                },
-            ),
-            secrets=RadarrSecrets(
-                **{  # type: ignore[arg-type]
-                    "hostname": hostname,
-                    "port": port,
-                    "protocol": protocol,
-                    "api_key": api_key,
-                },
+            instance_config=instance_config,
+            secrets=RadarrSecrets.get_from_url(
+                hostname=hostname,
+                port=port,
+                protocol=protocol,
+                api_key=api_key if api_key else None,
             ),
         )
         .yaml(),


### PR DESCRIPTION
* Fix a model validation error when dumping an instance configuration.
* Add the capability to auto-fetch the API key when dumping instance configurations (if authentication is disabled), by simply leaving the API key prompt blank.