### PR TITLE
Fix reading download client attributes

### DIFF
--- a/buildarr_radarr/config/settings/download_clients/torrent/freebox.py
+++ b/buildarr_radarr/config/settings/download_clients/torrent/freebox.py
@@ -105,7 +105,7 @@ class FreeboxDownloadClient(TorrentDownloadClient):
     """
 
     _implementation: str = "TorrentFreeboxDownload"
-    _base_remote_map: List[RemoteMapEntry] = [
+    _remote_map: List[RemoteMapEntry] = [
         ("hostname", "host", {"is_field": True}),
         ("port", "port", {"is_field": True}),
         ("use_ssl", "useSsl", {"is_field": True}),

--- a/buildarr_radarr/config/settings/download_clients/torrent/hadouken.py
+++ b/buildarr_radarr/config/settings/download_clients/torrent/hadouken.py
@@ -74,7 +74,7 @@ class HadoukenDownloadClient(TorrentDownloadClient):
     """
 
     _implementation: str = "Hadouken"
-    _base_remote_map: List[RemoteMapEntry] = [
+    _remote_map: List[RemoteMapEntry] = [
         ("hostname", "host", {"is_field": True}),
         ("port", "port", {"is_field": True}),
         ("use_ssl", "useSsl", {"is_field": True}),

--- a/buildarr_radarr/config/settings/download_clients/torrent/qbittorrent.py
+++ b/buildarr_radarr/config/settings/download_clients/torrent/qbittorrent.py
@@ -134,7 +134,7 @@ class QbittorrentDownloadClient(TorrentDownloadClient):
     """
 
     _implementation: str = "QBittorrent"
-    _base_remote_map: List[RemoteMapEntry] = [
+    _remote_map: List[RemoteMapEntry] = [
         ("hostname", "host", {"is_field": True}),
         ("port", "port", {"is_field": True}),
         ("use_ssl", "useSsl", {"is_field": True}),

--- a/buildarr_radarr/config/settings/download_clients/torrent/rtorrent.py
+++ b/buildarr_radarr/config/settings/download_clients/torrent/rtorrent.py
@@ -129,7 +129,7 @@ class RtorrentDownloadClient(TorrentDownloadClient):
     """
 
     _implementation: str = "RTorrent"
-    _base_remote_map: List[RemoteMapEntry] = [
+    _remote_map: List[RemoteMapEntry] = [
         ("hostname", "host", {"is_field": True}),
         ("port", "port", {"is_field": True}),
         ("use_ssl", "useSsl", {"is_field": True}),

--- a/buildarr_radarr/config/settings/download_clients/torrent/utorrent.py
+++ b/buildarr_radarr/config/settings/download_clients/torrent/utorrent.py
@@ -119,7 +119,7 @@ class UtorrentDownloadClient(TorrentDownloadClient):
     """
 
     _implementation: str = "UTorrent"
-    _base_remote_map: List[RemoteMapEntry] = [
+    _remote_map: List[RemoteMapEntry] = [
         ("hostname", "host", {"is_field": True}),
         ("port", "port", {"is_field": True}),
         ("use_ssl", "useSsl", {"is_field": True}),

--- a/buildarr_radarr/config/settings/download_clients/usenet/nzbget.py
+++ b/buildarr_radarr/config/settings/download_clients/usenet/nzbget.py
@@ -121,7 +121,7 @@ class NzbgetDownloadClient(UsenetDownloadClient):
     """
 
     _implementation: str = "Nzbget"
-    _base_remote_map: List[RemoteMapEntry] = [
+    _remote_map: List[RemoteMapEntry] = [
         ("hostname", "host", {"is_field": True}),
         ("port", "port", {"is_field": True}),
         ("use_ssl", "useSsl", {"is_field": True}),

--- a/buildarr_radarr/config/settings/download_clients/usenet/nzbvortex.py
+++ b/buildarr_radarr/config/settings/download_clients/usenet/nzbvortex.py
@@ -92,7 +92,7 @@ class NzbvortexDownloadClient(UsenetDownloadClient):
     """
 
     _implementation: str = "NzbVortex"
-    _base_remote_map: List[RemoteMapEntry] = [
+    _remote_map: List[RemoteMapEntry] = [
         ("hostname", "host", {"is_field": True}),
         ("port", "port", {"is_field": True}),
         (

--- a/buildarr_radarr/config/settings/download_clients/usenet/sabnzbd.py
+++ b/buildarr_radarr/config/settings/download_clients/usenet/sabnzbd.py
@@ -117,7 +117,7 @@ class SabnzbdDownloadClient(UsenetDownloadClient):
     """
 
     _implementation: str = "Sabnzbd"
-    _base_remote_map: List[RemoteMapEntry] = [
+    _remote_map: List[RemoteMapEntry] = [
         ("hostname", "host", {"is_field": True}),
         ("port", "port", {"is_field": True}),
         ("use_ssl", "useSsl", {"is_field": True}),


### PR DESCRIPTION
https://github.com/buildarr/buildarr-radarr/issues/33

Set the remote map class attribute correctly for the following download client types:

* FreeBox
* Hadouken
* qBittorrent
* rTorrent
* uTorrent
* NZBGet
* NZBVortex
* SABnzbd