### PR TITLE
Improve handling of unsupported resource types

### DIFF
--- a/buildarr_radarr/config/settings/custom_formats/__init__.py
+++ b/buildarr_radarr/config/settings/custom_formats/__init__.py
@@ -62,9 +62,12 @@ class RadarrCustomFormatsSettings(RadarrConfigBase):
                 api_schema_dict["implementation"]: api_schema_dict
                 for api_schema_dict in api_get(secrets, "/api/v3/customformat/schema")
             }
-        for customformat in self.definitions.values():
+        for customformat_name, customformat in self.definitions.items():
             if customformat.uses_trash_metadata():
-                customformat._post_init_render(api_condition_schema_dicts)
+                customformat._post_init_render(
+                    customformat_name=customformat_name,
+                    api_condition_schema_dicts=api_condition_schema_dicts,
+                )
 
     @classmethod
     def from_remote(cls, secrets: RadarrSecrets) -> Self:

--- a/buildarr_radarr/config/settings/custom_formats/custom_format.py
+++ b/buildarr_radarr/config/settings/custom_formats/custom_format.py
@@ -33,6 +33,7 @@ from pydantic import Field
 from typing_extensions import Annotated, Self
 
 from ....api import radarr_api_client
+from ....exceptions import RadarrConfigUnsupportedError
 from ....secrets import RadarrSecrets
 from ...types import RadarrConfigBase
 from .conditions.edition import EditionCondition
@@ -140,7 +141,11 @@ class CustomFormat(RadarrConfigBase):
     def uses_trash_metadata(self) -> bool:
         return bool(self.trash_id)
 
-    def _post_init_render(self, api_condition_schema_dicts: Dict[str, Dict[str, Any]]) -> None:
+    def _post_init_render(
+        self,
+        customformat_name: str,
+        api_condition_schema_dicts: Dict[str, Dict[str, Any]],
+    ) -> None:
         if not self.trash_id:
             return
         for customformat_file in (
@@ -166,13 +171,23 @@ class CustomFormat(RadarrConfigBase):
                                     for name, value in trash_condition["fields"].items()
                                 ],
                             }
+                            condition_implementation = api_condition_dict["implementation"]
+                            try:
+                                condition_type = CONDITION_TYPE_MAP[condition_implementation]
+                            except KeyError:
+                                raise RadarrConfigUnsupportedError(
+                                    (
+                                        f"Unsupported condition '{condition_name}' "
+                                        f"with implementation '{condition_implementation}' "
+                                        f"found in dynamic custom format '{customformat_name}' "
+                                        f"(trash_id='{self.trash_id}')"
+                                    ),
+                                ) from None
                             self.conditions[
                                 condition_name
-                            ] = CONDITION_TYPE_MAP[  # type: ignore[attr-defined]
-                                api_condition_dict["implementation"]
-                            ]._from_remote(
+                            ] = condition_type._from_remote(  # type: ignore[attr-defined]
                                 api_schema_dict=api_condition_schema_dicts[
-                                    api_condition_dict["implementation"]
+                                    condition_implementation
                                 ],
                                 api_condition=radarr.CustomFormatSpecificationSchema.from_dict(
                                     api_condition_dict,
@@ -191,23 +206,34 @@ class CustomFormat(RadarrConfigBase):
         api_condition_schema_dicts: Dict[str, Dict[str, Any]],
         api_customformat: radarr.CustomFormatResource,
     ) -> CustomFormat:
+        conditions: Dict[str, ConditionType] = {}
+        for api_condition in cast(
+            List[radarr.CustomFormatSpecificationSchema],
+            api_customformat.specifications,
+        ):
+            condition_implementation = api_condition.implementation
+            try:
+                condition_type = CONDITION_TYPE_MAP[condition_implementation]
+            except KeyError:
+                raise RadarrConfigUnsupportedError(
+                    (
+                        f"Unsupported condition '{api_condition.name}' "
+                        f"with implementation '{condition_implementation}' "
+                        f"found in remote custom format '{api_customformat.name}'"
+                    ),
+                ) from None
+            conditions[
+                api_condition.name
+            ] = condition_type._from_remote(  # type: ignore[attr-defined]
+                api_schema_dict=api_condition_schema_dicts[condition_implementation],
+                api_condition=api_condition,
+            )
         return cls(
             **cls.get_local_attrs(
                 remote_map=cls._remote_map,
                 remote_attrs=api_customformat.to_dict(),
             ),
-            conditions={
-                api_condition.name: CONDITION_TYPE_MAP[  # type: ignore[attr-defined]
-                    api_condition.implementation
-                ]._from_remote(
-                    api_schema_dict=api_condition_schema_dicts[api_condition.implementation],
-                    api_condition=api_condition,
-                )
-                for api_condition in cast(
-                    List[radarr.CustomFormatSpecificationSchema],
-                    api_customformat.specifications,
-                )
-            },
+            conditions=conditions,
         )
 
     def _create_remote(

--- a/buildarr_radarr/config/settings/custom_formats/custom_format.py
+++ b/buildarr_radarr/config/settings/custom_formats/custom_format.py
@@ -171,7 +171,7 @@ class CustomFormat(RadarrConfigBase):
                                     for name, value in trash_condition["fields"].items()
                                 ],
                             }
-                            condition_implementation = api_condition_dict["implementation"]
+                            condition_implementation: str = api_condition_dict["implementation"]
                             try:
                                 condition_type = CONDITION_TYPE_MAP[condition_implementation]
                             except KeyError:
@@ -211,21 +211,20 @@ class CustomFormat(RadarrConfigBase):
             List[radarr.CustomFormatSpecificationSchema],
             api_customformat.specifications,
         ):
-            condition_implementation = api_condition.implementation
             try:
-                condition_type = CONDITION_TYPE_MAP[condition_implementation]
+                condition_type = CONDITION_TYPE_MAP[api_condition.implementation]
             except KeyError:
                 raise RadarrConfigUnsupportedError(
                     (
                         f"Unsupported condition '{api_condition.name}' "
-                        f"with implementation '{condition_implementation}' "
+                        f"with implementation '{api_condition.implementation}' "
                         f"found in remote custom format '{api_customformat.name}'"
                     ),
                 ) from None
             conditions[
                 api_condition.name
             ] = condition_type._from_remote(  # type: ignore[attr-defined]
-                api_schema_dict=api_condition_schema_dicts[condition_implementation],
+                api_schema_dict=api_condition_schema_dicts[api_condition.implementation],
                 api_condition=api_condition,
             )
         return cls(

--- a/buildarr_radarr/config/settings/lists/__init__.py
+++ b/buildarr_radarr/config/settings/lists/__init__.py
@@ -165,6 +165,7 @@ class RadarrListsSettings(RadarrConfigBase):
                 else {}
             )
         api_importlist_config_dict = api_importlist_config.to_dict()
+        # TODO: Ignore unsupported import list types.
         return cls(
             **cls.get_local_attrs(cls._remote_map, api_importlist_config_dict),
             exclusions=ListExclusionsSettings.from_remote(secrets),

--- a/buildarr_radarr/exceptions.py
+++ b/buildarr_radarr/exceptions.py
@@ -50,7 +50,7 @@ class RadarrConfigError(RadarrError):
     pass
 
 
-class RadarrConfigUnsupportedError(RadarrError):
+class RadarrConfigUnsupportedError(RadarrConfigError):
     """
     Error raised when Buildarr attemps to manage an unsupported remote instance resource type.
     """

--- a/buildarr_radarr/exceptions.py
+++ b/buildarr_radarr/exceptions.py
@@ -42,6 +42,22 @@ class RadarrAPIError(RadarrError):
         super().__init__(msg)
 
 
+class RadarrConfigError(RadarrError):
+    """
+    Configuration exception base class.
+    """
+
+    pass
+
+
+class RadarrConfigUnsupportedError(RadarrError):
+    """
+    Error raised when Buildarr attemps to manage an unsupported remote instance resource type.
+    """
+
+    pass
+
+
 class RadarrSecretsError(RadarrError):
     """
     Secrets exception base class.

--- a/docs/configuration/settings/notifications.md
+++ b/docs/configuration/settings/notifications.md
@@ -508,9 +508,12 @@ Buildarr is unable to manage Plex Media Server notification connections at this 
 
 Please add the Plex Media Server notification connection manually in the Radarr UI.
 
-!!! warning
+!!! note
 
-    Ensure `delete_unmanaged` is set to `false` in Buildarr, otherwise the Plex Media Server notification connection will be removed from Radarr whenever Buildarr performs an update run.
+    When a Plex Media Server notification connection exists on the Radarr instance,
+    Buildarr will log warnings recognising it as an unsupported type.
+
+    These warnings can be ignored, as Buildarr will not modify the notification connection in any way.
 
 
 ## Prowl
@@ -866,9 +869,12 @@ Buildarr is unable to manage Trakt notification connections at this time, due to
 
 Please add the Trakt notification connection manually in the Radarr UI.
 
-!!! warning
+!!! note
 
-    Ensure `delete_unmanaged` is set to `false` in Buildarr, otherwise the Trakt notification connection will be removed from Radarr whenever Buildarr performs an update run.
+    When a Trakt notification connection exists on the Radarr instance,
+    Buildarr will log warnings recognising it as an unsupported type.
+
+    These warnings can be ignored, as Buildarr will not modify the notification connection in any way.
 
 
 ## Twitter
@@ -877,9 +883,12 @@ Buildarr is unable to manage Twitter notification connections at this time, due 
 
 Please add the Twitter notification connection manually in the Radarr UI.
 
-!!! warning
+!!! note
 
-    Ensure `delete_unmanaged` is set to `false` in Buildarr, otherwise the Twitter notification connection will be removed from Radarr whenever Buildarr performs an update run.
+    When a Twitter notification connection exists on the Radarr instance,
+    Buildarr will log warnings recognising it as an unsupported type.
+
+    These warnings can be ignored, as Buildarr will not modify the notification connection in any way.
 
 
 ## Webhook


### PR DESCRIPTION
https://github.com/buildarr/buildarr-radarr/issues/42

* Return easy-to-understand error messages when an unsupported condition type is found in a dynamic (loaded from TRaSH-Guides) or remote custom format.
* Ignore unsupported download client types on the remote instance, while logging the found type.
* Ignore unsupported indexer types on the remote instance, while logging the found type.
* Ignore unsupported notification connection types on the remote instance, while logging the found type.