### PR TITLE
Add missing preferred size quality definition

### DIFF
--- a/buildarr_radarr/config/settings/quality.py
+++ b/buildarr_radarr/config/settings/quality.py
@@ -239,6 +239,7 @@ class RadarrQualitySettings(RadarrConfigBase):
                     remote_map=[
                         ("title", "title", {"encoder": lambda v: v or definition_name}),
                         ("min", "minSize", {}),
+                        ("preferred", "preferredSize", {}),
                         ("max", "maxSize", {}),
                     ],
                     check_unmanaged=False,


### PR DESCRIPTION
It looks like everything is already in place, we just aren't passing in the preferred quality property.

This is for https://github.com/buildarr/buildarr-radarr/issues/46